### PR TITLE
nini: fix installation

### DIFF
--- a/exlibs/dotnet.exlib
+++ b/exlibs/dotnet.exlib
@@ -11,7 +11,8 @@ DEPENDENCIES="
 egacutil() {
     illegal_in_global_scope
 
-    edo gacutil /package "${PNV}" /gacdir /usr/${LIBDIR:-lib} /root "${IMAGE}/usr/${LIBDIR:-lib}" "${@}"
+    local libdir="/usr/$(exhost --target)/lib"
+    edo gacutil /package "${PNV}" /gacdir "${libdir}" /root "${IMAGE}/${libdir}" "${@}"
 }
 
 eautogac() {

--- a/packages/dev-libs/Nini/Nini-1.1.0.exheres-0
+++ b/packages/dev-libs/Nini/Nini-1.1.0.exheres-0
@@ -46,7 +46,7 @@ src_compile() {
         -keyfile:${PN}.snk
         AssemblyInfo.cs Config/*.cs Ini/*.cs Util/*.cs
     )
-    edo gmcs "${args[@]}"
+    edo mcs "${args[@]}"
 }
 
 src_install() {
@@ -58,7 +58,7 @@ src_install() {
 
     # from Gentoo ebuild
     local pv_major="$(ever range 1-2 ${PV})"
-    local pkgdir=/usr/${LIBDIR:-lib}/pkgconfig
+    local pkgdir=/usr/$(exhost --target)/pkgconfig
     dodir ${pkgdir}
     edo sed -e "s:@VERSION@:${PV}:" \
         -e "s:@NET_VERSION@:2.0:" \


### PR DESCRIPTION
1. mono currently does not include gmcs compiler
2. /usr/lib seems to be outdated