### PR TITLE
layout.conf: s/haskell/haskell-unofficial/

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -2,4 +2,4 @@ layout = exheres
 eapi_when_unknown = exheres-0
 eapi_when_unspecified = exheres-0
 profile_eapi_when_unspecified = exheres-0
-masters = arbor haskell mono java
+masters = arbor haskell-unofficial mono java


### PR DESCRIPTION
haskell is now deprecated in favour of haskell-unofficial
https://lists.exherbo.org/pipermail/exherbo-dev/2018-September/001563.html