### PR TITLE
pygit2: Bump to 0.28.2

### DIFF
--- a/packages/dev-scm/pygit2/pygit2-0.28.2.exheres-0
+++ b/packages/dev-scm/pygit2/pygit2-0.28.2.exheres-0
@@ -14,7 +14,9 @@ PLATFORMS="~amd64"
 
 DEPENDENCIES="
     build+run:
-        dev-python/cffi
+        dev-python/cffi[python_abis:*(-)?]
+        dev-python/six[python_abis:*(-)?]
+        dev-scm/libgit2[>=0.28.0]
         net-libs/libssh2
 "
 


### PR DESCRIPTION
Current blocker: [libgit2 bump MR](https://gitlab.exherbo.org/exherbo/net/merge_requests/179).