### PR TITLE
luajit: fix compilation without gcc

### DIFF
--- a/packages/dev-lang/LuaJIT/LuaJIT-2.0.5.exheres-0
+++ b/packages/dev-lang/LuaJIT/LuaJIT-2.0.5.exheres-0
@@ -20,6 +20,7 @@ BUGS_TO="virkony@gmail.com"
 src_compile() {
     local var
     myflags=(
+        CC=cc
         HOST_CC=$(exhost --build)-cc
         CROSS=$(exhost --tool-prefix)
         PREFIX=/usr


### PR DESCRIPTION
src/Makefile assumes TARGET_CC is $(CROSS)$(CC) where
CC is set to gcc by default. This breaks on systems without host gcc
(x86_64-pc-linux-gnu-cc points to clang). Explicitly set CC=cc to
force build system to use $(CROSS)cc instead of $(CROSS)gcc.